### PR TITLE
fix: delete existing SNAPSHOT version before deploying to GitHub Packages

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -157,13 +157,17 @@ jobs:
       - name: 🗑️ Delete existing SNAPSHOT version from GitHub Packages
         if: ${{ needs.build.outputs.is_release == 'false' }}
         run: |
-          GROUP_ID=$(mvn help:evaluate -Dexpression=project.groupId -q -DforceStdout)
-          ARTIFACT_ID=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
+          GROUP_ID=$(mvn -s "${SETTINGS_XML}" help:evaluate -Dexpression=project.groupId -q -DforceStdout)
+          ARTIFACT_ID=$(mvn -s "${SETTINGS_XML}" help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
           PACKAGE_NAME="${GROUP_ID}.${ARTIFACT_ID}"
           API_URL="/orgs/${GITHUB_REPOSITORY_OWNER}/packages/maven/${PACKAGE_NAME}/versions"
-          VERSION_ID=$(gh api "${API_URL}" --jq ".[] | select(.name == \"${PROJECT_VERSION}\") | .id" || true)
-          if [ -n "${VERSION_ID}" ]; then
-            gh api --method DELETE "${API_URL}/${VERSION_ID}"
+          VERSION_IDS=$(gh api --paginate "${API_URL}" --jq ".[] | select(.name == \"${PROJECT_VERSION}\") | .id" || true)
+          if [ -n "${VERSION_IDS}" ]; then
+            printf '%s\n' "${VERSION_IDS}" | while IFS= read -r VERSION_ID; do
+              if [ -n "${VERSION_ID}" ]; then
+                gh api --method DELETE "${API_URL}/${VERSION_ID}"
+              fi
+            done
           fi
       - name: 📦 Deploy to GitHub Packages
         # Releases should only be deployed to GitHub packages when the repo is private


### PR DESCRIPTION
## Summary
- Add a step to delete existing SNAPSHOT versions from GitHub Packages before deploying new ones
- Prevents `maven-metadata.xml` from accumulating historical SNAPSHOT entries that cause oldest-first resolution
- Dynamically derives the package name from `pom.xml` (`groupId.artifactId`) so it works for any extension without hardcoding

## Reference
- Issue: #101
- Original fix: [ch.sbb.polarion.extension.pdf-exporter#713](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter/pull/713)

Closes #101