### PR TITLE
ci: add workflow to block PR merges while release-please PR is pending

### DIFF
--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,0 +1,33 @@
+---
+# Blocks PR merges while a release-please snapshot PR is pending.
+# This prevents commits from landing between the release and the snapshot version bump.
+# Add the "release-please-guard" status check as required in branch protection rules.
+name: release-please-guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+jobs:
+  release-please-guard:
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'release-please--') != true
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check for pending release-please PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ github.base_ref }}
+        run: |-
+          RELEASE_PRS=$(gh pr list \
+            --base "$BASE_BRANCH" \
+            --author "app/release-please" \
+            --state open \
+            --json number,title \
+            --jq 'length')
+          if [ "$RELEASE_PRS" -gt 0 ]; then
+            echo "::error::There is an open release-please PR targeting '$BASE_BRANCH'. Merge that PR first before merging other PRs to ensure correct commit ordering."
+            exit 1
+          fi
+          echo "No pending release-please PR found. Good to go."

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,11 +1,13 @@
 ---
 # Blocks PR merges while a release-please snapshot PR is pending.
 # This prevents commits from landing between the release and the snapshot version bump.
-# Add the "release-please-guard" status check as required in branch protection rules.
+# Add the "release-please-guard" status check as required in branch protection rules,
+# and either enable a merge queue or require branches to be up to date before merging.
 name: release-please-guard
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 permissions: {}
 jobs:
   release-please-guard:

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -11,7 +11,6 @@ permissions: {}
 jobs:
   release-please-guard:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'release-please--') != true
     permissions:
       contents: read
     steps:
@@ -20,7 +19,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           BASE_BRANCH: ${{ github.base_ref }}
+          HEAD_BRANCH: ${{ github.head_ref }}
         run: |-
+          if [[ "$HEAD_BRANCH" == release-please--* ]]; then
+            echo "Release-please PR — skipping guard."
+            exit 0
+          fi
           VERSION=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
             --jq '.content' | base64 -d | \
             awk '/<parent>/{p=1} /<\/parent>/{p=0;next} !p && /<version>/{gsub(/.*<version>|<\/version>.*/,""); print; exit}')

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -24,10 +24,9 @@ jobs:
         run: |-
           RELEASE_PRS=$(gh pr list \
             --base "$BASE_BRANCH" \
-            --author "app/release-please" \
             --state open \
-            --json number,title \
-            --jq 'length')
+            --json number,title,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-please--"))] | length')
           if [ "$RELEASE_PRS" -gt 0 ]; then
             echo "::error::There is an open release-please PR targeting '$BASE_BRANCH'. Merge that PR first before merging other PRs to ensure correct commit ordering."
             exit 1

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,13 +1,12 @@
 ---
 # Blocks PR merges while a release-please snapshot PR is pending.
 # This prevents commits from landing between the release and the snapshot version bump.
-# Add the "release-please-guard" status check as required in branch protection rules,
-# and either enable a merge queue or require branches to be up to date before merging.
+# Add the "release-please-guard" status check as required in branch protection rules
+# and enable "Require branches to be up to date before merging".
 name: release-please-guard
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  merge_group:
 permissions: {}
 jobs:
   release-please-guard:
@@ -20,7 +19,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          BASE_BRANCH: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.base_ref }}
+          BASE_BRANCH: ${{ github.base_ref }}
         run: |-
           VERSION=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
             --jq '.content' | base64 -d | \

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          BASE_BRANCH: ${{ github.base_ref }}
+          BASE_BRANCH: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.base_ref }}
         run: |-
           VERSION=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
             --jq '.content' | base64 -d | \

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,6 +1,6 @@
 ---
-# Blocks PR merges while a release-please snapshot PR is pending.
-# This prevents commits from landing between the release and the snapshot version bump.
+# Blocks PR merges when the base branch pom.xml version is not a *-SNAPSHOT version.
+# This prevents commits from landing after a release and before the snapshot version bump is merged.
 # Add the "release-please-guard" status check as required in branch protection rules
 # and enable "Require branches to be up to date before merging".
 name: release-please-guard
@@ -21,6 +21,7 @@ jobs:
           BASE_BRANCH: ${{ github.base_ref }}
           HEAD_BRANCH: ${{ github.head_ref }}
         run: |-
+          set -euo pipefail
           if [[ "$HEAD_BRANCH" == release-please--* ]]; then
             echo "Release-please PR — skipping guard."
             exit 0
@@ -28,6 +29,10 @@ jobs:
           VERSION=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
             --jq '.content' | base64 -d | \
             awk '/<parent>/{p=1} /<\/parent>/{p=0;next} !p && /<version>/{gsub(/.*<version>|<\/version>.*/,""); print; exit}')
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Failed to extract project version from pom.xml on '$BASE_BRANCH'."
+            exit 1
+          fi
           if [[ "$VERSION" != *-SNAPSHOT ]]; then
             echo "::error::Version on '$BASE_BRANCH' is '$VERSION' (not a SNAPSHOT). Merge the release-please snapshot PR first before merging other PRs."
             exit 1

--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -14,21 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.head_ref, 'release-please--') != true
     permissions:
-      pull-requests: read
+      contents: read
     steps:
-      - name: Check for pending release-please PR
+      - name: Check base branch version is SNAPSHOT
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           BASE_BRANCH: ${{ github.base_ref }}
         run: |-
-          RELEASE_PRS=$(gh pr list \
-            --base "$BASE_BRANCH" \
-            --state open \
-            --json number,title,headRefName \
-            --jq '[.[] | select(.headRefName | startswith("release-please--"))] | length')
-          if [ "$RELEASE_PRS" -gt 0 ]; then
-            echo "::error::There is an open release-please PR targeting '$BASE_BRANCH'. Merge that PR first before merging other PRs to ensure correct commit ordering."
+          VERSION=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
+            --jq '.content' | base64 -d | \
+            awk '/<parent>/{p=1} /<\/parent>/{p=0;next} !p && /<version>/{gsub(/.*<version>|<\/version>.*/,""); print; exit}')
+          if [[ "$VERSION" != *-SNAPSHOT ]]; then
+            echo "::error::Version on '$BASE_BRANCH' is '$VERSION' (not a SNAPSHOT). Merge the release-please snapshot PR first before merging other PRs."
             exit 1
           fi
-          echo "No pending release-please PR found. Good to go."
+          echo "Version is '$VERSION'. Good to go."

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,10 @@ Releases within our project are exclusively overseen by designated code owners, 
 4. Subsequent to each release, the process iterates to update the version to X.Y.Z-SNAPSHOT, thereby preparing a new pull request for the forthcoming X.Y.Z version release.
 
 
+### Branch Protection
+
+The [`release-please-guard`](/.github/workflows/release-please-guard.yml) workflow prevents PRs from merging while a release-please snapshot PR is pending. This ensures the snapshot version bump lands immediately after the release, avoiding misordered commits on the target branch. To enforce this, add `release-please-guard` as a required status check in your branch protection rules for `main` and any `release-v*` branches.
+
 For comprehensive information, please consult the [Release Please documentation](https://github.com/googleapis/release-please).
 
 ## LTS (Long-Term Support) Releases

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ Releases within our project are exclusively overseen by designated code owners, 
 
 ### Branch Protection
 
-The [`release-please-guard`](/.github/workflows/release-please-guard.yml) workflow prevents PRs from merging while a release-please snapshot PR is pending. This ensures the snapshot version bump lands immediately after the release, avoiding misordered commits on the target branch. To enforce this, add `release-please-guard` as a required status check in your branch protection rules for `main` and any `release-v*` branches, and enable "Require branches to be up to date before merging" (or use a merge queue). This ensures PRs that previously passed the guard are rechecked when a release-please PR is opened.
+The [`release-please-guard`](/.github/workflows/release-please-guard.yml) workflow prevents PRs from merging while a release-please snapshot PR is pending. This ensures the snapshot version bump lands immediately after the release, avoiding misordered commits on the target branch. To enforce this, add `release-please-guard` as a required status check in your branch protection rules for `main` and any `release-v*` branches, and enable "Require branches to be up to date before merging". This ensures PRs that previously passed the guard are rechecked when a release-please PR is opened.
 
 For comprehensive information, please consult the [Release Please documentation](https://github.com/googleapis/release-please).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ Releases within our project are exclusively overseen by designated code owners, 
 
 ### Branch Protection
 
-The [`release-please-guard`](/.github/workflows/release-please-guard.yml) workflow prevents PRs from merging while a release-please snapshot PR is pending. This ensures the snapshot version bump lands immediately after the release, avoiding misordered commits on the target branch. To enforce this, add `release-please-guard` as a required status check in your branch protection rules for `main` and any `release-v*` branches.
+The [`release-please-guard`](/.github/workflows/release-please-guard.yml) workflow prevents PRs from merging while a release-please snapshot PR is pending. This ensures the snapshot version bump lands immediately after the release, avoiding misordered commits on the target branch. To enforce this, add `release-please-guard` as a required status check in your branch protection rules for `main` and any `release-v*` branches, and enable "Require branches to be up to date before merging" (or use a merge queue). This ensures PRs that previously passed the guard are rechecked when a release-please PR is opened.
 
 For comprehensive information, please consult the [Release Please documentation](https://github.com/googleapis/release-please).
 


### PR DESCRIPTION
## Summary

- Adds `release-please-guard` workflow that checks if the base branch `pom.xml` has a SNAPSHOT version — if not (meaning a release just landed and the snapshot bump hasn't merged yet), the check fails and blocks the PR
- Release-please's own PRs (`release-please--*` branches) pass the guard unconditionally
- Documents the required branch protection setup in RELEASE.md

Closes #122

## Test plan

- [x] Validated on SchweizerischeBundesbahnen/ch.sbb.polarion.extension.open-source-polarion-java-repo-template (tested blocking and passing scenarios)
- [ ] Add `release-please-guard` as a required status check in branch protection rules after merge
- [ ] Enable "Require branches to be up to date before merging"