### PR TITLE
ci: add pull-requests:read to actionlint caller permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,3 +13,4 @@ jobs:
     permissions:
       checks: write
       contents: read
+      pull-requests: read


### PR DESCRIPTION
## Summary

- Adds `pull-requests: read` permission to the actionlint caller workflow, required by the upstream reusable workflow (github-workflows-polarion#57)

Closes #121

## Test plan

- [ ] Verify actionlint workflow passes on this PR