### PR TITLE
ci: add actions:read to claude-code-review caller permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,7 @@ jobs:
   claude-review:
     uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude-code-review.yml@main
     permissions:
+      actions: read
       contents: read
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Summary

- Adds `actions: read` permission to the claude-code-review caller workflow, required by the upstream reusable workflow's `github_ci` MCP server

Closes #127

## Test plan

- [ ] Verify Claude Code Review workflow no longer fails with `startup_failure`