### PR TITLE
fix: use github.ref_name for Sonar branch name on push events

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -60,15 +60,15 @@ jobs:
       - name: 📦 Build with Maven for Pushes
         if: github.event_name == 'push'
         env:
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          BRANCH_NAME: ${{ github.ref_name }}
           IS_PUBLIC: ${{ github.event.repository.visibility == 'public' }}
           IS_TEMPLATE: ${{ github.event.repository.is_template }}
         run: |
           SONAR_ARGS=()
           if [ "${IS_PUBLIC}" = "true" ] && [ "${IS_TEMPLATE}" != "true" ]; then
             SONAR_ARGS+=(sonar:sonar "-Dsonar.exclusions=.github/**")
-            if [ -n "${GITHUB_HEAD_REF}" ]; then
-              SONAR_ARGS+=("-Dsonar.branch.name=${GITHUB_HEAD_REF}")
+            if [ -n "${BRANCH_NAME}" ]; then
+              SONAR_ARGS+=("-Dsonar.branch.name=${BRANCH_NAME}")
             fi
           fi
           mvn --batch-mode -s "${SETTINGS_XML}" clean verify "${SONAR_ARGS[@]}"


### PR DESCRIPTION
## Summary

- Replaces `github.head_ref` with `github.ref_name` in the push build step for Sonar branch analysis
- `github.head_ref` is only populated for `pull_request` events — on push it's always empty, so Sonar never received branch context

Closes #119

## Test plan

- [ ] Verify Sonar push analysis includes correct branch name