### PR TITLE
ci: use reusable release-please-guard workflow

### DIFF
--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,8 +1,4 @@
 ---
-# Blocks PR merges when the base branch pom.xml version is not a *-SNAPSHOT version.
-# This prevents commits from landing after a release and before the snapshot version bump is merged.
-# Add the "release-please-guard" status check as required in branch protection rules
-# and enable "Require branches to be up to date before merging".
 name: release-please-guard
 on:
   pull_request:
@@ -10,31 +6,6 @@ on:
 permissions: {}
 jobs:
   release-please-guard:
-    runs-on: ubuntu-latest
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-release-please-guard.yml@main
     permissions:
       contents: read
-    steps:
-      - name: Check base branch version is SNAPSHOT
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          BASE_BRANCH: ${{ github.base_ref }}
-          HEAD_BRANCH: ${{ github.head_ref }}
-        run: |-
-          set -euo pipefail
-          if [[ "$HEAD_BRANCH" == release-please--* ]]; then
-            echo "Release-please PR — skipping guard."
-            exit 0
-          fi
-          VERSION=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
-            --jq '.content' | base64 -d | \
-            awk '/<parent>/{p=1} /<\/parent>/{p=0;next} !p && /<version>/{gsub(/.*<version>|<\/version>.*/,""); print; exit}')
-          if [[ -z "$VERSION" ]]; then
-            echo "::error::Failed to extract project version from pom.xml on '$BASE_BRANCH'."
-            exit 1
-          fi
-          if [[ "$VERSION" != *-SNAPSHOT ]]; then
-            echo "::error::Version on '$BASE_BRANCH' is '$VERSION' (not a SNAPSHOT). Merge the release-please snapshot PR first before merging other PRs."
-            exit 1
-          fi
-          echo "Version is '$VERSION'. Good to go."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,4 @@
 - **Logging**: Polarion logs: `<POLARION_HOME>/polarion/logs/main/*.log`
 - **Branch conventions**: Conventional commits enforced by commitizen (pre-commit hook). Feature branches: `feature/<name>`, bug fixes: `fix/<name>`, LTS branches: `release-v*` (e.g., `release-v6`).
 - **Pre-commit hooks block internal patterns**: some org-specific identifiers are treated as secrets. Run `pre-commit run -a` after implementation.
+- **Reusable workflow caller permissions**: When calling reusable workflows from `github-workflows-polarion`, the caller must grant all permissions the reusable workflow's job declares. The reusable workflow can only restrict, never escalate beyond what the caller passes. Always check the reusable workflow's job-level `permissions:` and mirror them in the caller.


### PR DESCRIPTION
## Summary

- Replace inline `release-please-guard` workflow with a caller to the reusable workflow from `github-workflows-polarion` (SchweizerischeBundesbahnen/github-workflows-polarion#73)
- Add CLAUDE.md gotcha about reusable workflow caller permissions

## Test plan

- [ ] Verify the `release-please-guard` check passes on this PR
- [ ] Verify the guard still blocks when base branch has a non-SNAPSHOT version

Closes #131