### PR TITLE
ci: remove SNAPSHOT delete workaround

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -170,21 +170,6 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
-      - name: 🗑️ Delete existing SNAPSHOT version from GitHub Packages
-        # May fail if the SNAPSHOT is the only version in the package,
-        # as GitHub API does not allow deleting the last version.
-        # Safe to ignore — no accumulation problem with a single version.
-        if: ${{ needs.build.outputs.is_release == 'false' }}
-        continue-on-error: true
-        run: |
-          GROUP_ID=$(mvn -s "${SETTINGS_XML}" help:evaluate -Dexpression=project.groupId -q -DforceStdout)
-          ARTIFACT_ID=$(mvn -s "${SETTINGS_XML}" help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
-          PACKAGE_NAME="${GROUP_ID}.${ARTIFACT_ID}"
-          API_URL="/orgs/${GITHUB_REPOSITORY_OWNER}/packages/maven/${PACKAGE_NAME}/versions"
-          VERSION_ID=$(gh api --paginate "${API_URL}" --jq ".[] | select(.name == \"${PROJECT_VERSION}\") | .id" || true)
-          if [ -n "${VERSION_ID}" ]; then
-            gh api --method DELETE "${API_URL}/${VERSION_ID}"
-          fi
       - name: 📦 Deploy to GitHub Packages
         # Releases should only be deployed to GitHub Packages when the repo is private
         # Snapshots are always deployed to GitHub Packages


### PR DESCRIPTION
## Summary
- Removes the `🗑️ Delete existing SNAPSHOT version from GitHub Packages` step from `.github/workflows/maven-build.yml` (`deploy-github-packages` job).
- The workaround originated in [`pdf-exporter#713`](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter/pull/713) (closing [`pdf-exporter#712`](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter/issues/712)) to compensate for a bug in Ansible's `community.general` `maven_artifact` module — it returned the oldest SNAPSHOT instead of the latest. It was then propagated into this template.
- Upstream fix https://github.com/ansible-collections/community.general/pull/11501 has landed and been verified working — workaround no longer needed.
- Same revert was already merged in [`pdf-exporter#796`](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter/pull/796).

Closes #135

## Test plan
- [ ] CI green on this PR
- [ ] After merge, downstream repos that copied this pattern from the template still need the same revert (tracked in #135 — see "Downstream repos that need the same revert" section)