### PR TITLE
feat: add CodeQL workflow via reusable-codeql-java

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,22 @@
+---
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Weekly, off-peak Sunday — matches the cadence default setup uses.
+    - cron: 17 5 * * 0
+permissions: {}
+jobs:
+  analyze:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-codeql-java.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      packages: read
+    secrets:
+      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` — a thin caller that delegates to the new `reusable-codeql-java.yml` reusable on the central workflows repo.
- Replaces the absent default CodeQL setup with `build-mode: manual` + the same compile-only Maven build, giving CodeQL the full classpath and lifting type-information coverage past CodeQL's 85% threshold.

## Dependency — opened as draft

Caller pins `@main` of the central workflows repo. The reusable lands in https://github.com/SchweizerischeBundesbahnen/github-workflows-polarion/pull/77; this PR will mark ready and pass CI once that one merges.

## Test plan

- [ ] Mark ready after the upstream reusable PR merges
- [ ] Confirm the CodeQL workflow runs green on this PR (compile-only Maven build, no test execution, no Sonar)
- [ ] Confirm no database-quality warning is emitted

Closes #137