### PR TITLE
fix: drop --extends=minimal so redocly.yaml governs openapi lint

### DIFF
--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -12,4 +12,3 @@ jobs:
       contents: read
     with:
       spec-path: docs/openapi.json
-      redocly-args: --extends=minimal


### PR DESCRIPTION
## Summary

`.github/workflows/openapi-validation.yml` passed `redocly-args: --extends=minimal`, which overrides the `recommended` ruleset configured in this repo's `redocly.yaml` (`extends: [recommended]`) — silently relaxing API-contract checks. The workflow arg and the config file contradicted each other.

This drops the arg so `redocly.yaml` is the single source of truth for the ruleset. The reusable workflow defaults `redocly-args` to `""`, so no argument is needed.

Since consumer repos are bootstrapped/synced from this template, the downgrade propagated downstream — surfaced during a template sync into `ch.sbb.polarion.extension.docx-exporter`.

Closes #150

## Test plan

- [x] `redocly lint docs/openapi.json` passes clean under `recommended` (exit 0) with the arg removed
- [ ] CI green on this PR

> Note: direct push to `main` was attempted per request but is correctly blocked by the branch ruleset (requires `build` + `release-please-guard` checks), so this goes through a PR.