### PR TITLE
chore: remove 'synchronize' from pull request types

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@
 name: Claude Code Review
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened]
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
This pull request makes a small update to the workflow trigger for the Claude Code Review GitHub Actions workflow. The workflow will no longer run when a pull request is synchronized (i.e., when new commits are pushed to an existing PR).
