### PR TITLE
ci: run CodeQL on release-v* branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@
 name: CodeQL
 on:
   push:
-    branches: [main]
+    branches: [main, release-v*]
   pull_request:
-    branches: [main]
+    branches: [main, release-v*]
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # Weekly, off-peak Sunday — matches the cadence default setup uses.


### PR DESCRIPTION
## Problem

The `CodeQL` workflow (`.github/workflows/codeql.yml`) triggers only on `main`:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
```

Repositories generated from this template that maintain `release-v*` branches are protected by an organization ruleset requiring a **CodeQL** code-scanning result on the head commit. Since the workflow never runs for PRs targeting a release branch, the required result never arrives and those PRs become permanently unmergeable (reported as `BLOCKED` despite being approved with all checks green). This was first observed on a downstream extension repository.

## Fix

Extend the `push` and `pull_request` branch filters to include the `release-v*` pattern so CodeQL also runs for release-branch PRs. Repositories generated from this template then inherit correct CodeQL coverage for release branches.

Closes #155