### PR TITLE
feat(release-please-guard): run guard on push to renovate branches

### DIFF
--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -3,6 +3,11 @@ name: release-please-guard
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Runs on Renovate automerge branches so the required "release-please-guard"
+  # check exists on the commit Renovate fast-forwards onto the default branch
+  # (branch automerge pushes directly with no PR).
+  push:
+    branches: [renovate/**]
 permissions: {}
 jobs:
   release-please-guard:


### PR DESCRIPTION
## Problem

Renovate branch automerge fast-forwards a `renovate/*` commit **directly onto the default branch with no pull request**. Because `release-please-guard.yml` only triggered on `pull_request`, the required `release-please-guard` check never ran on the pushed commit and the push was rejected:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Required status check "release-please-guard / release-please-guard" is expected.
```

## Change

Add a `push` trigger scoped to `renovate/**` so the guard runs on the commit Renovate fast-forwards onto the default branch, reporting under the same `release-please-guard / release-please-guard` check name.

Resulting behaviour:
- Default branch at `-SNAPSHOT` → check passes → automerge proceeds.
- Default branch at a released (non-SNAPSHOT) version → check fails → Renovate holds the merge until the release-please snapshot bump lands.

Pull request behaviour is unchanged.

## Dependency

Requires SchweizerischeBundesbahnen/github-workflows-polarion#84 (reusable guard supporting push context) to be merged first.

Tracks #160.