### PR TITLE
ci: publish SNAPSHOTs to sbb.jfrog.io and stop using GitHub Packages

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     outputs:
       project_version: ${{ steps.project_metadata.outputs.version }}
       is_release: ${{ steps.project_metadata.outputs.is_release }}
@@ -107,7 +106,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     env:
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME }}
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN }}
@@ -139,18 +137,59 @@ jobs:
             -Dmaven.wagon.http.connectionTimeout=3600000 \
             -Dmaven.wagon.http.readTimeout=3600000 \
             -Dcentral-publishing-maven-plugin.autoPublish=${{ github.event.repository.visibility == 'public' }}
-  # Deploy to GitHub Packages (snapshots from main only) and upload release assets to GitHub Release
-  # LTS branches (release-v*) only upload release assets, no snapshot deployment
-  deploy-github-packages:
+  # Publish to JFrog Artifactory (sbb.jfrog.io/artifactory/polarion-mvn).
+  # SNAPSHOTs from main always; releases only when the repo is private (public
+  # releases go to Maven Central, see deploy-maven-central). Reuses the artifact
+  # built by the build job via deploy:deploy-file (no rebuild).
+  deploy-jfrog-io:
     needs: build
     if: ${{ github.ref == 'refs/heads/main' || (needs.build.outputs.is_release == 'true' && startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+    env:
+      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
+      PROJECT_VERSION: ${{ needs.build.outputs.project_version }}
+    steps:
+      - name: 📄 Checkout the repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: 📥 Download build artifacts
+        # The artifacts are generated in the 'build' job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: maven-artifacts
+          path: target/
+      - name: 🧱 Set up JDK and Maven
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5.3.0
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+      - name: 📦 Deploy to JFrog Artifactory
+        # SNAPSHOTs always; releases only when the repo is private (public releases
+        # go to Maven Central). Main JAR + POM only — sources/javadoc are produced
+        # only for Maven Central releases.
+        if: ${{ needs.build.outputs.is_release == 'false' || github.event.repository.visibility == 'private' }}
+        run: |
+          jar=(target/*-"${PROJECT_VERSION}".jar)
+          mvn --batch-mode -s "${SETTINGS_XML}" deploy:deploy-file \
+            -DrepositoryId=jfrog_io \
+            -Durl=https://sbb.jfrog.io/artifactory/polarion-mvn \
+            -DpomFile=pom.xml \
+            -Dfile="${jar[0]}"
+  # Attach the built JAR to the GitHub Release page. Releases are published to Maven
+  # Central (public repos) or JFrog Artifactory (private repos); SNAPSHOTs go to JFrog.
+  upload-release-assets:
+    needs: build
+    if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
+    runs-on: ubuntu-latest
+    permissions:
       contents: write
-      packages: write
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      GITHUB_REPO_NAME: ${{ github.repository }}
       PROJECT_VERSION: ${{ needs.build.outputs.project_version }}
     steps:
       - name: 📄 Checkout the repository
@@ -164,23 +203,6 @@ jobs:
         with:
           name: maven-artifacts
           path: target/
-      - name: 🧱 Set up JDK and Maven
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5.3.0
-        with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: 📦 Deploy to GitHub Packages
-        # Releases should only be deployed to GitHub Packages when the repo is private
-        # Snapshots are always deployed to GitHub Packages
-        if: ${{ needs.build.outputs.is_release == 'false' || github.event.repository.visibility == 'private' }}
-        run: |
-          mvn --batch-mode -s "${SETTINGS_XML}" deploy \
-            -Dmaven.test.skip=true \
-            -Dmaven.javadoc.skip=true \
-            -Dmaven.source.skip=true \
-            -P deploy-github-packages
       - name: 📦 Upload assets to GitHub Release
-        if: ${{ needs.build.outputs.is_release == 'true' }}
         run: |-
           gh release upload "v${PROJECT_VERSION}" "target/*-${PROJECT_VERSION}.jar" --clobber

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,11 +1,11 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <activeProfiles>
-        <activeProfile>github</activeProfile>
+        <activeProfile>jfrog</activeProfile>
     </activeProfiles>
     <profiles>
         <profile>
-            <id>github</id>
+            <id>jfrog</id>
             <repositories>
                 <repository>
                     <id>jfrog_io</id>
@@ -15,15 +15,13 @@
                         <enabled>true</enabled>
                         <updatePolicy>never</updatePolicy>
                     </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
                 </repository>
             </repositories>
             <pluginRepositories/>
-        </profile>
-        <profile>
-            <id>deploy-github-packages</id>
-            <properties>
-                <altDeploymentRepository>github::https://maven.pkg.github.com/${env.GITHUB_REPO_NAME}</altDeploymentRepository>
-            </properties>
         </profile>
     </profiles>
     <servers>
@@ -37,11 +35,6 @@
                     </property>
                 </httpHeaders>
             </configuration>
-        </server>
-        <server>
-            <id>github</id>
-            <username>${env.GITHUB_ACTOR}</username>
-            <password>${env.GITHUB_TOKEN}</password>
         </server>
         <server>
             <id>sonatype-central</id>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Gotchas
 
 - **`ch.sbb.polarion.extension.generic`** is the parent project providing reusable infrastructure for all Polarion plugins in this org (settings framework, REST base classes, OSGi helpers, etc.). Before implementing anything cross-cutting, check if it already exists there.
-- **Maven Settings**: Builds require `.mvn/settings.xml` (JFrog, GitHub Packages, Sonatype credentials via env vars). CI passes it with `-s .mvn/settings.xml`. `.mvn/maven.config` auto-activates the Polarion version profile.
+- **Maven Settings**: Builds require `.mvn/settings.xml` (JFrog Artifactory, Sonatype credentials via env vars). CI passes it with `-s .mvn/settings.xml`. `.mvn/maven.config` auto-activates the Polarion version profile.
 - **Polarion Dependencies**: You must extract dependencies from the Polarion installer using [polarion-artifacts-deployer](https://github.com/SchweizerischeBundesbahnen/polarion-artifacts-deployer) before the Maven build will work.
 - **Local Polarion Installation**: Requires `POLARION_HOME` environment variable. Use the `install-to-local-polarion` Maven profile: `mvn clean install -P install-to-local-polarion`
 - **After any code change**: Delete `<POLARION_HOME>/data/workspace/.config` before restarting Polarion or changes won't be picked up.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,15 +53,17 @@ The `release-v*` pattern in the workflow automatically recognizes new LTS branch
 
 ### Deployment Matrix
 
-| Branch | Version Type | Maven Central | GitHub Packages | GitHub Release |
-|--------|--------------|---------------|-----------------|----------------|
+| Branch | Version Type | Maven Central | JFrog Artifactory | GitHub Release |
+|--------|--------------|---------------|-------------------|----------------|
 | `main` | SNAPSHOT | - | ✓ | - |
-| `main` | Release | ✓ | - | ✓ |
+| `main` | Release | ✓ (public) | ✓ (private only) | ✓ |
 | `release-v*` | SNAPSHOT | - | - | - |
-| `release-v*` | Release | ✓ | - | ✓ |
+| `release-v*` | Release | ✓ (public) | ✓ (private only) | ✓ |
 
 ### Notes
 
-- SNAPSHOT versions from LTS branches are NOT deployed to GitHub Packages
+- SNAPSHOTs are published to JFrog Artifactory (`sbb.jfrog.io/artifactory/polarion-mvn`); publishing to GitHub Packages was removed
+- Releases go to Maven Central for public repositories, or to JFrog Artifactory for private repositories
+- SNAPSHOT versions from LTS branches are NOT deployed anywhere
 - Only release versions from LTS branches are deployed to Maven Central
 - Each LTS branch operates independently with its own release PR


### PR DESCRIPTION
## Summary

Propagates the publishing scheme that was piloted on the PDF Exporter plugin into the Java repo template, so every repository generated from this template inherits it. The pilot was intentionally scoped to one plugin first; this PR brings the template (the source of truth) in line.

New scheme:
- **Releases** → Maven Central for public repositories, JFrog Artifactory for private repositories
- **SNAPSHOTs** → JFrog Artifactory (`sbb.jfrog.io/artifactory/polarion-mvn`)
- **GitHub Packages** → no longer used

## Changes

**`.github/workflows/maven-build.yml`**
- Replace the `deploy-github-packages` job with a dedicated `deploy-jfrog-io` job that publishes via `deploy:deploy-file`, reusing the artifact built by the `build` job (no rebuild). SNAPSHOTs from `main` always; releases only when the repository is private.
- Split out `upload-release-assets` to attach the release JAR to the GitHub Release, tightened to releases only so it no longer spins up a runner on snapshot pushes just to skip the upload.
- Drop the now-unused `packages: read` permission from the `build` and `deploy-maven-central` jobs.

**`.mvn/settings.xml`**
- Enable `<snapshots>` resolution on the `jfrog_io` repository so published snapshots are consumable.
- Remove the `deploy-github-packages` profile and the `github` server; rename the read profile `github` → `jfrog`.

**Docs**
- Update the `RELEASE.md` deployment matrix and the `CLAUDE.md` Maven Settings note to match.

## Notes

- The template's existing pinned action versions (e.g. `setup-java` v5.3.0) are preserved; only the publishing logic changed.
- Downstream repositories will receive this change through the normal template-sync process.
- Requires the `IO_JFROG_SBB_POLARION_TOKEN` secret, which the org already provides to repositories generated from this template.

## Validation

- `actionlint` and the full `pre-commit` suite (incl. `zizmor`) pass.

Refs: the PDF Exporter pilot PR (#859 there).