### PR TITLE
chore: align the template with the maintenance sweep

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -22,7 +22,6 @@ jobs:
     env:
       IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR: true
       GITHUB_TOKEN: ${{ github.token }}  # Providing this prevents reaching the GitHub request limits
     steps:
       - name: 📄 Checkout the repository

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -81,6 +81,27 @@
         ]
       }
     },
+    "/api/disclaimer": {
+      "get": {
+        "operationId": "getDisclaimer",
+        "responses": {
+          "default": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "HTML help article"
+          }
+        },
+        "summary": "Returns the build-generated DISCLAIMER help article shown on the Usage Disclaimer page",
+        "tags": [
+          "Extension Information"
+        ]
+      }
+    },
     "/api/hello": {
       "get": {
         "operationId": "hello",

--- a/pom.xml
+++ b/pom.xml
@@ -136,9 +136,6 @@
                 <artifactId>swagger-maven-plugin-jakarta</artifactId>
                 <configuration>
                     <outputFormat>JSON</outputFormat>
-                    <!-- Stable ordering, so a rebuild does not reshuffle docs/openapi.json into a diff
-                         that says nothing. -->
-                    <sortOutput>true</sortOutput>
                     <resourcePackages>
                         <!-- `info` backs the About page (/version, /configuration-properties,
                              /configuration-status, /readme, /user-guide). Uncomment `roles` when the

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,10 @@
              build without a GITHUB_TOKEN stays lenient; CI sets the environment variable to true, and a
              broken conversion then fails the build instead of shipping an empty About page. Unset, the
              property does not resolve to a boolean and the plugin reads it as false. -->
-        <!--suppress UnresolvedMavenProperty -->
-        <markdown2html-maven-plugin.failOnError>${env.MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR}</markdown2html-maven-plugin.failOnError>
+        <!-- A broken README.md -> about.html conversion fails the build instead of shipping an
+             empty About page. markdown2html renders locally since 1.7.x - no GitHub API, no token -
+             so the same setting is right in CI, in a deploy job and on a developer machine. -->
+        <markdown2html-maven-plugin.failOnError>true</markdown2html-maven-plugin.failOnError>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,6 @@
 
         <web.app.name>${maven-jar-plugin.Extension-Context}</web.app.name>
 
-        <!-- README.md -> about.html conversion. The parent defaults to failOnError=false so a local
-             build without a GITHUB_TOKEN stays lenient; CI sets the environment variable to true, and a
-             broken conversion then fails the build instead of shipping an empty About page. Unset, the
-             property does not resolve to a boolean and the plugin reads it as false. -->
         <!-- A broken README.md -> about.html conversion fails the build instead of shipping an
              empty About page. markdown2html renders locally since 1.7.x - no GitHub API, no token -
              so the same setting is right in CI, in a deploy job and on a developer machine. -->
@@ -138,7 +134,7 @@
                     <outputFormat>JSON</outputFormat>
                     <resourcePackages>
                         <!-- `info` backs the About page (/version, /configuration-properties,
-                             /configuration-status, /readme, /user-guide). Uncomment `roles` when the
+                             /configuration-status, /readme, /user-guide, /disclaimer). Uncomment `roles` when the
                              extension adds RSP's Authorization page, and `settings` when it gets its
                              first named setting. -->
                         <package>ch.sbb.polarion.extension.generic.rest.controller.info</package>

--- a/src/test/java/ch/sbb/polarion/extension/extension_name/ExtensionNameAppServletTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/extension_name/ExtensionNameAppServletTest.java
@@ -61,8 +61,11 @@ class ExtensionNameAppServletTest {
     @Test
     void rejectsAnotherWebappContext() {
         // The extension's other context: a request meant for it must not be served from this app.
+        HttpServletRequest request = requestFor("/polarion/extension-name/ui/app/index.html");
+
+        // Only the call under test may throw here, so the assertion cannot pass for the wrong reason.
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-                () -> servlet.service(requestFor("/polarion/extension-name/ui/app/index.html"), response));
+                () -> servlet.service(request, response));
 
         assertEquals("Unsupported resource path", thrown.getMessage());
     }

--- a/src/test/java/ch/sbb/polarion/extension/extension_name/ExtensionNameAppServletTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/extension_name/ExtensionNameAppServletTest.java
@@ -1,16 +1,69 @@
 package ch.sbb.polarion.extension.extension_name;
 
-import ch.sbb.polarion.extension.generic.GenericUiServlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+/**
+ * Pins the webapp context this servlet passes to {@code GenericUiServlet}.
+ * <p>
+ * That string is the whole behaviour of the class, and it has to stay identical to the resource
+ * directory {@code src/main/resources/webapp/extension-name-app/} and to every URL in
+ * {@code META-INF/hivemodule.xml}: the base class serves a request only when its URI starts with
+ * {@code /polarion/<webAppName>/ui/} and strips exactly that prefix to find the resource. A typo
+ * there breaks resource serving at runtime, which is why this asserts the routing rather than the
+ * class hierarchy the compiler already guarantees.
+ */
 class ExtensionNameAppServletTest {
 
-    @Test
-    void instantiatesAsGenericUiServlet() {
-        ExtensionNameAppServlet servlet = new ExtensionNameAppServlet();
+    private ExtensionNameAppServlet servlet;
+    private ServletContext servletContext;
+    private HttpServletResponse response;
 
-        assertThat(servlet).isInstanceOf(GenericUiServlet.class);
+    @BeforeEach
+    void setUp() throws Exception {
+        servletContext = mock(ServletContext.class);
+        ServletConfig servletConfig = mock(ServletConfig.class);
+        when(servletConfig.getServletContext()).thenReturn(servletContext);
+
+        servlet = new ExtensionNameAppServlet();
+        servlet.init(servletConfig);
+        response = mock(HttpServletResponse.class);
+    }
+
+    private HttpServletRequest requestFor(String uri) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(uri);
+        return request;
+    }
+
+    @Test
+    void servesFromTheAppWebappContext() throws Exception {
+        when(servletContext.getResourceAsStream(anyString())).thenReturn(null);
+
+        servlet.service(requestFor("/polarion/extension-name-app/ui/app/index.html"), response);
+
+        // The context prefix is stripped, so what is looked up is the path inside the webapp.
+        verify(servletContext).getResourceAsStream("/app/index.html");
+        verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    @Test
+    void rejectsAnotherWebappContext() {
+        // The extension's other context: a request meant for it must not be served from this app.
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> servlet.service(requestFor("/polarion/extension-name/ui/app/index.html"), response));
+
+        assertEquals("Unsupported resource path", thrown.getMessage());
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/extension_name/ExtensionNameAppServletTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/extension_name/ExtensionNameAppServletTest.java
@@ -63,7 +63,6 @@ class ExtensionNameAppServletTest {
         // The extension's other context: a request meant for it must not be served from this app.
         HttpServletRequest request = requestFor("/polarion/extension-name/ui/app/index.html");
 
-        // Only the call under test may throw here, so the assertion cannot pass for the wrong reason.
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
                 () -> servlet.service(request, response));
 


### PR DESCRIPTION
### Proposed changes

Brings the template in line with the family maintenance sweep now open across the extension repositories, so a repository generated from it starts where they end up.

- **`build: always fail on a broken README conversion`** - drops `MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR` from the workflow and sets `markdown2html-maven-plugin.failOnError` to `true` directly. markdown2html renders the markdown locally since 1.7.x - no GitHub API call and no token - so there is nothing environment-dependent left to toggle. The indirection also only covered the `build` job, so `deploy-maven-central` re-ran the conversion ungated and shipped the `about.html` the gate never saw.
- **`build: drop the redundant sortOutput`** - the generic parent already sets it in its `pluginManagement` for `swagger-maven-plugin-jakarta`, and Maven merges the managed configuration element by element. Verified by regenerating `docs/openapi.json` with and without the child element: the output is byte-identical. The spec is regenerated in the same commit because the 15.11.0 bump did not do it - `/disclaimer` is inherited from the parent, so the template documents `/api/disclaimer` now.
- **`test: pin the app servlet's webapp context`** - the test asserted an `instanceof` relation the compiler already guarantees, so the only way it could fail was the constructor throwing. It now drives `service()` and asserts that a request under `/polarion/extension-name-app/ui/` resolves to the resource path inside the webapp, and that a request under the extension's other context is rejected. That string has to stay identical to `src/main/resources/webapp/extension-name-app/` and to every URL in `hivemodule.xml`, and nothing caught a typo in it before.

The parent bump to 15.11.0 itself is already on `main` (#renovate), so this branch no longer carries it.

### Verification

`mvn package` green, including the two new servlet tests. Regenerating `docs/openapi.json` after the change produces no further diff.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
