### PR TITLE
ci: add Polarion Semgrep wrapper alongside the CodeQL one

### DIFF
--- a/.github/workflows/polarion-semgrep.yml
+++ b/.github/workflows/polarion-semgrep.yml
@@ -16,3 +16,4 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read

--- a/.github/workflows/polarion-semgrep.yml
+++ b/.github/workflows/polarion-semgrep.yml
@@ -1,0 +1,18 @@
+---
+name: Polarion Semgrep
+on:
+  push:
+    branches: [main, release-v*]
+  pull_request:
+    branches: [main, release-v*]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Weekly, off-peak Sunday — twenty minutes after the CodeQL run.
+    - cron: 37 5 * * 0
+permissions: {}
+jobs:
+  semgrep:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-polarion-semgrep.yml@main
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
Adds the thin Polarion Semgrep wrapper alongside the existing CodeQL one. Implements #138.

`reusable-polarion-semgrep.yml` is now on the default branch of `github-workflows-polarion` (SchweizerischeBundesbahnen/github-workflows-polarion#95 is merged), so the `@main` ref resolves and this repository's own `Polarion Semgrep` check runs. That resolution failure was the only reason this was a draft.

The wrapper mirrors `codeql.yml`: the same triggers, a weekly schedule twenty minutes after the CodeQL run, minimal job permissions, and no secrets, because the scan does not build the project. `actions: read` is granted for the same reason `codeql.yml` grants it — the reusable workflow requests it for `upload-sarif`, which the documentation lists as required on private repositories, and a called workflow's permissions can only narrow the caller's.

## What downstream repositories get

The reusable workflow runs the Polarion rule pack only — no `p/java`, no `p/owasp-top-ten` — because CodeQL `security-extended` and SonarCloud already cover generic Java and OWASP in repositories generated from this template. Alerts arrive under their own Code Scanning category, `polarion-semgrep`, so they do not mix with the CodeQL ones.

Measured across the five existing extension repositories at current `main`, the pack reports 18 findings in total, every one `polarion-transaction-no-permission-check` at INFO severity. A freshly generated repository will see none. The other seven rules fire nowhere on the corpus and act as regression guards on new code, so this check is deliberately not proposed as required.

## Verification already done upstream

The reusable workflow has produced a real Code Scanning analysis on the first consumer: SchweizerischeBundesbahnen/ch.sbb.polarion.extension.api-extender#149 uploaded 8 rules and 1 result under category `polarion-semgrep`, matching the count predicted for that repository.

Until release-please SchweizerischeBundesbahnen/github-workflows-polarion#29 merges there is no tag on `github-workflows-polarion`, so `@main` is the only ref available. Pinning to a tag is a follow-up.

Refs #138, SchweizerischeBundesbahnen/github-workflows-polarion#76
